### PR TITLE
ENG-1331 Mainnet loan offers

### DIFF
--- a/config/production.config.json
+++ b/config/production.config.json
@@ -10,15 +10,24 @@
         "tokenContractAddress": "0x5cbeb7a0df7ed85d82a472fd56d81ed550f3ea95"
       },
       "lending": {
-        "enabled": false,
+        "enabled": true,
         "lendingWalletAddress": "0xB53f8A9db5eaD2148402BE181968d2ff10f02cB0",
         "offerRules": [
           {
-            "filter": "attributes.State === 'TX'",
-            "loanPrincipal": "Math.min(property.value * 0.5, wallet.balances.usdc * 0.3)",
+            "filter": "attributes['Confidence Score'] >= 2_000",
+            "loanPrincipal": "Math.min(attributes['Estimated value in USD'] <= 5_000 ? attributes['Estimated value in USD'] * 0.2 : attributes['Estimated value in USD'] >= 50_000 ? attributes['Estimated value in USD'] * 0.5 : (attributes['Estimated value in USD'] - 5_000) * 45_000 * .3 + .2, wallet.balances.usdc)",
             "loanApr": "0.15",
-            "loanDurationDays": 20,
-            "offerExpirationDays": 30
+            "loanDurationDays": 180,
+            "offerExpirationDays": 30,
+            "percentChanceToLend": 100
+          },
+          {
+            "filter": "attributes['Confidence Score'] >= 2_000",
+            "loanPrincipal": "Math.min(attributes['Estimated value in USD'] <= 5_000 ? attributes['Estimated value in USD'] * 0.2 : attributes['Estimated value in USD'] >= 50_000 ? attributes['Estimated value in USD'] * 0.5 : (attributes['Estimated value in USD'] - 5_000) * 45_000 * .3 + .2, wallet.balances.usdc)",
+            "loanApr": "0.12",
+            "loanDurationDays": 90,
+            "offerExpirationDays": 30,
+            "percentChanceToLend": 100
           }
         ],
         "periodicity": "0 15 7 * * *"

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,9 +172,15 @@ class FabricaLoanBot {
         rule.percentChanceToLend &&
         Math.floor(Math.random() * 100) > rule.percentChanceToLend
       ) {
+        console.log(
+          `Percent chance to lend of ${rule.percentChanceToLend} not cleared: skipping offer for token ${tokenIdentity} on ${Blockchain.logString(tokenIdentity)}`,
+        )
         return
       }
       if (rule.filter && !vm.runInContext(rule.filter, context)) {
+        console.log(
+          `Property doesn't meet the rule's filter "${rule.filter}": skipping offer for token ${tokenIdentity} on ${Blockchain.logString(tokenIdentity)}`,
+        )
         return
       }
       const principal = new Decimal(
@@ -206,7 +212,10 @@ class FabricaLoanBot {
         principal: this.decimalToUsdcScaleString(nftfi, principal),
         repayment: this.decimalToUsdcScaleString(nftfi, repayment),
       }
-      console.log('Loan terms', terms)
+      console.log(
+        `Creating loan offer for token ${tokenIdentity} on ${Blockchain.logString(tokenIdentity)} with these terms`,
+        terms,
+      )
       try {
         await this.nftfi.createOffer(
           tokenIdentity,


### PR DESCRIPTION
This checks daily (there aren't many production tokens) to see if the production mainnet lending wallet 0xB53f8A9db5eaD2148402BE181968d2ff10f02cB0 has any active (not expired) loan offers on each mainnet token, and if not, and if the property has a provenance score of at least 2000, creates two loan offers, one at 15% APR for 6 months, and another at 12% APR for 3 months. The loan principal is between 20% and 50% of the value of the property, on a linear progression between those under $5k in value, and those over $50k in value.

It will begin creating production offers the moment this PR merges and builds. I tested the curve logic and offer generation locally on Sepolia.