### PR TITLE
ENG-1342 Target specific borrower

### DIFF
--- a/config/develop.config.json
+++ b/config/develop.config.json
@@ -11,8 +11,9 @@
       },
       "nftfi": {
         "apiBaseUri": "https://sdk-api.nftfi.com",
-        "website": "https://app.nftfi.com",
-        "loanContractAddress": "0xd0a40eB7FD94eE97102BA8e9342243A2b2E22207"
+        "bnplContractAddress": "0x959879019288C4799B6e7c26eeECd0F0D499fF88",
+        "loanContractAddress": "0xd0a40eB7FD94eE97102BA8e9342243A2b2E22207",
+        "website": "https://app.nftfi.com"
       },
       "transactions": {
         "gasLimit": 1000000,
@@ -33,8 +34,9 @@
       },
       "nftfi": {
         "apiBaseUri": "https://sepolia-integration-sdk-api.nftfi.com",
-        "website": "https://sepolia-integration.nftfi.com",
-        "loanContractAddress": "0x170605b4753eB8837a08D3e58aF012B68eeD06b9"
+        "bnplContractAddress": "0x94306cff51b11b46482b8593811008573270f330",
+        "loanContractAddress": "0x170605b4753eB8837a08D3e58aF012B68eeD06b9",
+        "website": "https://sepolia-integration.nftfi.com"
       },
       "transactions": {
         "gasLimit": 1000000,

--- a/config/example.local.config.json
+++ b/config/example.local.config.json
@@ -22,6 +22,7 @@
         "lendingWalletAddress": "[Use your own wallet]",
         "offerRules": [
           {
+            "borrower": "token.owner",
             "filter": "token.attributes.State === 'California'",
             "loanPrincipal": "Math.min(token.attributes['Estimated value in USD'] * 0.5, wallet.balances.usdc * 0.3)",
             "loanApr": "0.15",
@@ -29,6 +30,7 @@
             "offerExpirationDays": 7
           },
           {
+            "borrower": "bnpl.address",
             "loanPrincipal": "Math.min(token.attributes['Estimated value in USD'] * 0.4, wallet.balances.usdc * 0.3)",
             "loanApr": "0.25",
             "loanDurationDays": 120,

--- a/config/production.config.json
+++ b/config/production.config.json
@@ -59,6 +59,7 @@
         "lendingWalletAddress": "0xBD43d28CE84b7549B2afC8D4C9e9c15Ad492Cdb4",
         "offerRules": [
           {
+            "borrower": "bnpl.address",
             "loanPrincipal": "Math.min(token.attributes['Estimated value in USD'] * 0.5, wallet.balances.usdc * 0.3)",
             "loanApr": "0.15",
             "loanDurationDays": 20,
@@ -66,6 +67,7 @@
             "percentChanceToLend": 100
           },
           {
+            "borrower": "token.owner",
             "loanPrincipal": "Math.min(token.attributes['Estimated value in USD'] * 0.4, wallet.balances.usdc * 0.2)",
             "loanApr": "0.25",
             "loanDurationDays": 120,
@@ -73,6 +75,7 @@
             "percentChanceToLend": 20
           },
           {
+            "borrower": "token.owner",
             "loanPrincipal": "Math.min(token.attributes['Estimated value in USD'] * 0.2, wallet.balances.usdc * 0.25)",
             "loanApr": "0.10",
             "loanDurationDays": 60,
@@ -80,6 +83,7 @@
             "percentChanceToLend": 20
           },
           {
+            "borrower": "token.owner",
             "loanPrincipal": "Math.min(token.attributes['Estimated value in USD'] * 0.25, wallet.balances.usdc * 0.4)",
             "loanApr": "0.18",
             "loanDurationDays": 180,

--- a/src/nftfi.ts
+++ b/src/nftfi.ts
@@ -9,12 +9,12 @@ import { Blockchain } from './blockchain'
 import { Config, NetworkName } from './types/config'
 import { ContractIdentity } from './types/contract-identity'
 import { EthereumAddress, ZERO_ADDRESS } from './types/ethereum-address'
+import { FabricaToken } from './types/fabrica-token'
 import { LoanTerms } from './types/loan-terms'
 import { NftfiOffer, NftfiOffers } from './types/nftfi-offer'
 import { NonEmptyString } from './types/non-empty-string'
 import { isPlainObject } from './types/plain-object'
 import { PositiveIntegerString } from './types/positive-integer-string'
-import { TokenIdentity } from './types/token-identity'
 
 export class Nftfi {
   constructor(
@@ -98,15 +98,12 @@ export class Nftfi {
   }
 
   public readonly createOffer = async (
-    tokenIdentity: TokenIdentity,
+    token: FabricaToken,
     terms: LoanTerms,
     walletPrivateKey: NonEmptyString,
     borrowerAddress: EthereumAddress = ZERO_ADDRESS,
   ): Promise<NftfiOffer> => {
-    const nftfi = await this.getNftfiClient(
-      tokenIdentity.network,
-      walletPrivateKey,
-    )
+    const nftfi = await this.getNftfiClient(token.network, walletPrivateKey)
     // Make sure the lender wallet has enough coin
     const lenderBalance = await nftfi.erc20.balanceOf({
       account: { address: nftfi.account.getAddress() },
@@ -129,7 +126,7 @@ export class Nftfi {
       }),
     )
     // 2. Sum up the principals of the lender's outstanding NFTfi offers
-    const offers = await this.getOffers(tokenIdentity, tokenIdentity.tokenId)
+    const offers = await this.getOffers(token, token.tokenId)
     const sumOfOutstandingOffers = offers.reduce(
       (
         sum: bigint,
@@ -154,8 +151,8 @@ export class Nftfi {
     const createOffer = {
       terms,
       nft: {
-        address: tokenIdentity.contractAddress,
-        id: tokenIdentity.tokenId,
+        address: token.contractAddress,
+        id: token.tokenId,
       },
       borrower: { address: borrowerAddress },
       nftfi: { contract: { name: nftfi.config.loan.fixed.v2_3.name } },

--- a/src/types/lending.network.config.ts
+++ b/src/types/lending.network.config.ts
@@ -13,6 +13,7 @@ export const LendingNetworkConfig = z.object({
   lendingWalletPrivateKey: HexString,
   offerRules: z.array(
     z.object({
+      borrower: NonEmptyString.optional(),
       filter: NonEmptyString.optional(),
       loanPrincipal: NonEmptyString,
       loanApr: PositiveFloatString,

--- a/src/types/nftfi.network.config.ts
+++ b/src/types/nftfi.network.config.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod'
-import { HttpUrlString } from './url-strings'
-import { NonEmptyString } from './non-empty-string'
+
 import { EthereumAddress } from './ethereum-address'
-import { HexString, PrefixedHexString } from './hex-string'
+import { NonEmptyString } from './non-empty-string'
+import { HttpUrlString } from './url-strings'
 
 export const NftfiNetworkConfig = z.object({
   apiBaseUri: HttpUrlString.optional(),
   apiKey: NonEmptyString,
+  bnplContractAddress: EthereumAddress,
   loanContractAddress: EthereumAddress,
   website: HttpUrlString.optional(),
 })


### PR DESCRIPTION
### Changes
- Rules may now include a `borrower` property, which is evaluated as Javascript
- VM context now includes `token.owner` and `bnplContract` (the address of the BuyWithNftfiLoan contract)
- Borrower can be a literal, wrapped in single quotes, e.g. `"'0xd……eadbeefdeadbeefdeadbeefdeadbeefdeadbeef'"`